### PR TITLE
Add Fusion Python Extension SDK prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,17 @@ All projects in this repository use a shared Visual Studio props file, found in 
 2. If you are converting from one SDK to another, most of the work will be done for you.
 3. Adding a new project configuration (example, you have Edittime, and you add Edittime Unicode), the props file will read the project configuration name and apply the settings for Edittime and Unicode; making it non-debug, adding the `_UNICODE` defines, etc.
 
+## Python-first Fusion SDK prototype
+
+The repository now contains an experimental Python SDK (`fusionpy_sdk`) that mirrors the proposed Fusion Python Extension SDK for Windows. It includes:
+
+* Decorators and an `Extension` base class for defining actions, conditions, expressions, properties, and lifecycle hooks.
+* Manifest validation helpers for `fusion_extension.yml`/`.json` descriptors.
+* A CLI (`python -m fusionpy_sdk.cli`) with `init`, `validate`, `build`, `run`, and `publish` subcommands to scaffold, validate, bundle, and stage Python extensions for the Windows host bridge.
+* Build tooling that freezes Python bytecode and packages declared resources for distribution.
+
+See `docs/fusionpy-sdk.md` for architecture details and usage guidance.
+
 ## SDK variants
 
 ### MMF2SDK
@@ -148,4 +159,3 @@ If you don't want to provide Fusion 2.0 ANSI compatiblity, you can remove the no
 [Edif Clickteam forum thread]: https://community.clickteam.com/threads/61692-Edif-Extension-Development-Is-Fun
 [Windows SDK archive]: https://developer.microsoft.com/en-us/windows/downloads/sdk-archive/
 [Link to PuTTY]: https://www.chiark.greenend.org.uk/~sgtatham/putty/latest.html
-

--- a/docs/fusionpy-sdk.md
+++ b/docs/fusionpy-sdk.md
@@ -1,0 +1,55 @@
+Fusion Python Extension SDK (Prototype)
+=======================================
+
+This repository now includes a Python-first SDK prototype (`fusionpy_sdk`) that mirrors the proposed Fusion SDK design.
+It focuses on developer experience while acknowledging the host bridge and Windows-first distribution model.
+
+Architecture highlights
+-----------------------
+
+* **Host bridge boundary** – The Python package assumes a C++ host that embeds CPython and forwards Fusion callbacks.
+  The `RuntimeBridge` class defines the minimal surface that the host is expected to implement (logging, resource access,
+  overlap checks). Native shims can attach a concrete implementation at runtime.
+* **Manifest validation** – `fusion_extension.yml`/`.json` files are parsed and validated for required fields,
+  ACE signatures, resource lists, dependency metadata, sandboxing hints, and capabilities.
+* **Python adapter layer** – Decorators (`@action`, `@condition`, `@expression`, `@property_field`) and an `Extension`
+  base class gather ACE metadata from type hints and docstrings, wiring lifecycle hooks (`on_create`, `on_frame`,
+  `on_save`, `on_load`).
+* **Resource loader** – Build tooling copies declared assets into the package bundle alongside frozen Python bytecode.
+* **Sandboxing hooks** – Manifest fields for dependency isolation (`dependencies`) and execution policy (`sandbox`)
+  are parsed and carried into build metadata for future host enforcement.
+
+Developer workflow
+------------------
+
+1. `python -m fusionpy_sdk.cli init MyExtension --path my_extension`  
+   Generates `fusion_extension.yml`, a sample module, and an assets folder.
+2. `python -m fusionpy_sdk.cli validate my_extension/fusion_extension.yml`  
+   Ensures required metadata and ACE declarations are present.
+3. `python -m fusionpy_sdk.cli build my_extension/fusion_extension.yml --mode release`  
+   Validates, freezes bytecode, copies resources, and emits a zip-based extension payload in `fusionpy_build/`.
+4. `python -m fusionpy_sdk.cli run --fusion-path "C:\\Program Files\\Fusion\\Fusion.exe"`  
+   Placeholder that documents expected launch semantics; host integration is required for injection/hot-reload.
+5. `python -m fusionpy_sdk.cli publish my_extension/fusion_extension.yml --feed <path or url>`  
+   Stub that records intent; signing/upload flows can be added later.
+
+Manifest schema (summary)
+-------------------------
+
+* `name`, `id`, `version`, `entrypoint` – required identifiers.
+* `runtime` – Fusion version and Python runtime expectations.
+* `capabilities` – permissions such as `filesystem`, `network`, `registry`.
+* `actions`, `conditions`, `expressions` – ACE definitions with `id` and `name` plus optional parameters.
+* `properties` – editor-visible properties.
+* `resources.include/exclude` – glob patterns for bundling assets.
+* `dependencies` – vendored wheels or shared-runtime hints.
+* `sandbox` – isolation preferences (e.g., `mode: venv`, timeouts, memory ceilings).
+* `metadata` – free-form data for future host features.
+
+Extending the prototype
+-----------------------
+
+* Replace `RuntimeBridge` with a host-provided implementation that proxies Fusion services.
+* Augment `build_extension` to inject compiled host binaries, sign packages, and produce `.mfx` outputs.
+* Implement `run`/`publish` subcommands to integrate with Fusion installations and feed infrastructure.
+* Add Cython build paths for performance-sensitive ACEs; leverage the manifest `dependencies` section to pull wheels.

--- a/fusionpy_sdk/__init__.py
+++ b/fusionpy_sdk/__init__.py
@@ -1,0 +1,37 @@
+"""
+Fusion Python Extension SDK (fusionpy_sdk)
+==========================================
+
+This package provides authoring tools for writing Fusion extensions in
+pure Python while keeping compatibility with Fusion's native extension
+model. The public surface intentionally mirrors the proposed developer
+workflow:
+
+* Decorators and a lightweight ``Extension`` base class for defining ACE
+  tables and lifecycle hooks.
+* Manifest utilities to validate ``fusion_extension`` descriptors.
+* Build helpers to freeze Python sources, vendor resources, and emit a
+  distributable archive ready for the host bridge to consume.
+* A CLI entry point (``fusionpy``) that exposes ``init``, ``validate``,
+  ``build``, ``run``, and ``publish`` commands.
+
+The code here is platform-neutral but geared toward the Windows-first
+distribution model outlined in the proposal.
+"""
+
+from .decorators import action, condition, expression, property_field
+from .extension import Extension
+from .manifest import Manifest, load_manifest, validate_manifest
+
+__all__ = [
+    "Extension",
+    "Manifest",
+    "action",
+    "condition",
+    "expression",
+    "property_field",
+    "load_manifest",
+    "validate_manifest",
+]
+
+__version__ = "0.1.0"

--- a/fusionpy_sdk/builder.py
+++ b/fusionpy_sdk/builder.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import compileall
+import json
+import shutil
+import zipfile
+from pathlib import Path
+from typing import Iterable, List, Optional, Tuple
+
+from .manifest import Manifest, load_manifest
+
+
+DEFAULT_BUILD_DIR = Path("fusionpy_build")
+
+
+def _copy_resources(manifest_dir: Path, resource_root: Path, include: Iterable[str], exclude: Iterable[str]) -> List[Path]:
+    copied: List[Path] = []
+    for pattern in include:
+        for path in (manifest_dir / pattern).parent.glob((manifest_dir / pattern).name):
+            if any(path.match(ex_pat) for ex_pat in exclude):
+                continue
+            dest = resource_root / path.relative_to(manifest_dir)
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(path, dest)
+            copied.append(dest)
+    return copied
+
+
+def _freeze_sources(source_root: Path) -> None:
+    compileall.compile_dir(source_root, force=True, quiet=1)
+
+
+def build_extension(manifest_path: Path, *, output_dir: Optional[Path] = None, target: str = "win32", mode: str = "debug") -> Path:
+    """
+    Validate the manifest, freeze Python sources, bundle resources, and emit an archive.
+    The resulting file is a zip-based payload intended to be consumed by the host bridge.
+    """
+
+    manifest_path = manifest_path.resolve()
+    manifest_dir = manifest_path.parent
+    manifest = load_manifest(manifest_path)
+    build_root = (output_dir or DEFAULT_BUILD_DIR).resolve()
+    build_root.mkdir(parents=True, exist_ok=True)
+
+    staging_dir = build_root / f"{manifest.id}-{manifest.version}-{mode}"
+    if staging_dir.exists():
+        shutil.rmtree(staging_dir)
+    staging_dir.mkdir(parents=True, exist_ok=True)
+
+    # Copy sources
+    src_dest = staging_dir / "src"
+    shutil.copytree(manifest_dir, src_dest, dirs_exist_ok=True)
+
+    # Freeze bytecode for faster startup
+    _freeze_sources(src_dest)
+
+    # Bundle resources explicitly listed
+    resources = manifest.resources or {}
+    include = resources.get("include", [])
+    exclude = resources.get("exclude", [])
+    resource_root = staging_dir / "resources"
+    resource_root.mkdir(exist_ok=True)
+    _copy_resources(manifest_dir, resource_root, include, exclude)
+
+    # Write build metadata
+    build_info = {
+        "target": target,
+        "mode": mode,
+        "manifest": manifest.__dict__,
+    }
+    (staging_dir / "build.json").write_text(json.dumps(build_info, indent=2), encoding="utf-8")
+
+    # Emit distributable archive
+    archive_name = build_root / f"{manifest.id}-{manifest.version}-{target}-{mode}.zip"
+    if archive_name.exists():
+        archive_name.unlink()
+    with zipfile.ZipFile(archive_name, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for path in staging_dir.rglob("*"):
+            if path.is_file():
+                zf.write(path, arcname=path.relative_to(staging_dir))
+    return archive_name

--- a/fusionpy_sdk/cli.py
+++ b/fusionpy_sdk/cli.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+from .builder import build_extension
+from .manifest import load_manifest
+from .scaffold import init_extension
+
+
+logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(message)s")
+logger = logging.getLogger("fusionpy.cli")
+
+
+def cmd_init(args: argparse.Namespace) -> None:
+    init_extension(args.name, Path(args.path))
+    logger.info("Scaffold created at %s", Path(args.path).resolve())
+
+
+def cmd_validate(args: argparse.Namespace) -> None:
+    manifest = load_manifest(args.manifest)
+    logger.info("Manifest valid for '%s' v%s (entrypoint: %s)", manifest.name, manifest.version, manifest.entrypoint)
+    logger.info("Capabilities: %s", ", ".join(manifest.capabilities) or "none")
+    logger.info("Actions: %d | Conditions: %d | Expressions: %d", len(manifest.actions), len(manifest.conditions), len(manifest.expressions))
+
+
+def cmd_build(args: argparse.Namespace) -> None:
+    archive = build_extension(Path(args.manifest), output_dir=Path(args.output), target=args.target, mode=args.mode)
+    logger.info("Build complete: %s", archive)
+
+
+def cmd_run(args: argparse.Namespace) -> None:
+    fusion_path = Path(args.fusion_path)
+    if not fusion_path.exists():
+        logger.error("Fusion executable not found at %s", fusion_path)
+        sys.exit(1)
+    logger.info("Would launch Fusion at %s with hot-reload enabled: %s", fusion_path, args.hot_reload)
+    logger.info("Integration with the host bridge is required for actual injection.")
+
+
+def cmd_publish(args: argparse.Namespace) -> None:
+    manifest = load_manifest(args.manifest)
+    logger.info("Publishing '%s' version %s", manifest.name, manifest.version)
+    logger.info("Feed: %s | Channel: %s", args.feed or "local", args.channel)
+    logger.info("Package signing and upload to feeds are intentionally stubbed in this prototype.")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Fusion Python Extension SDK CLI")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_init = sub.add_parser("init", help="Create a new extension scaffold")
+    p_init.add_argument("name", help="Extension name, e.g. MyExtension")
+    p_init.add_argument("--path", default=".", help="Target directory for the scaffold")
+    p_init.set_defaults(func=cmd_init)
+
+    p_validate = sub.add_parser("validate", help="Validate a fusion_extension manifest")
+    p_validate.add_argument("manifest", help="Path to fusion_extension.yml or .json")
+    p_validate.set_defaults(func=cmd_validate)
+
+    p_build = sub.add_parser("build", help="Build the extension package")
+    p_build.add_argument("manifest", help="Path to fusion_extension.yml or .json")
+    p_build.add_argument("--output", default="fusionpy_build", help="Output directory for build artifacts")
+    p_build.add_argument("--target", default="win32", help="Build target (win32 by default)")
+    p_build.add_argument("--mode", default="debug", choices=["debug", "release"], help="Build profile")
+    p_build.set_defaults(func=cmd_build)
+
+    p_run = sub.add_parser("run", help="Launch Fusion with the extension injected")
+    p_run.add_argument("--fusion-path", required=True, help="Path to Fusion executable")
+    p_run.add_argument("--hot-reload", action="store_true", help="Enable hot reload when safe")
+    p_run.set_defaults(func=cmd_run)
+
+    p_publish = sub.add_parser("publish", help="Publish the built extension to a feed")
+    p_publish.add_argument("manifest", help="Path to fusion_extension.yml or .json")
+    p_publish.add_argument("--feed", help="Target feed URL or filesystem path")
+    p_publish.add_argument("--channel", default="stable", help="Release channel (stable/beta/dev)")
+    p_publish.set_defaults(func=cmd_publish)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    args.func(args)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/fusionpy_sdk/decorators.py
+++ b/fusionpy_sdk/decorators.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import functools
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional
+
+
+@dataclass
+class ACEParameter:
+    name: str
+    type_hint: Optional[str] = None
+    description: Optional[str] = None
+
+
+@dataclass
+class ACEEntry:
+    kind: str
+    title: str
+    method_name: str
+    display: Optional[str] = None
+    parameters: List[ACEParameter] = field(default_factory=list)
+    returns: Optional[str] = None
+    flags: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class PropertyField:
+    label: str
+    default: Any = None
+    description: Optional[str] = None
+    editor: Optional[str] = None
+    flags: Dict[str, Any] = field(default_factory=dict)
+
+
+def _build_ace_entry(kind: str, title: str, display: Optional[str], flags: Dict[str, Any]) -> Callable:
+    def decorator(func: Callable) -> Callable:
+        annotations = getattr(func, "__annotations__", {})
+        params = [
+            ACEParameter(name=name, type_hint=type_hint.__name__ if hasattr(type_hint, "__name__") else str(type_hint))
+            for name, type_hint in annotations.items()
+            if name != "return"
+        ]
+        returns = annotations.get("return")
+        entry = ACEEntry(
+            kind=kind,
+            title=title,
+            method_name=func.__name__,
+            display=display,
+            parameters=params,
+            returns=returns.__name__ if hasattr(returns, "__name__") else (str(returns) if returns else None),
+            flags=flags or {},
+        )
+        setattr(func, "__fusion_ace__", entry)
+        return functools.wraps(func)(func)
+
+    return decorator
+
+
+def action(title: str, *, display: Optional[str] = None, **flags: Any) -> Callable:
+    """
+    Mark a method as a Fusion action.
+    The decorator captures type hints for parameter marshaling and editor UI.
+    """
+
+    return _build_ace_entry("action", title, display, flags)
+
+
+def condition(title: str, *, display: Optional[str] = None, **flags: Any) -> Callable:
+    """
+    Mark a method as a Fusion condition (returns a boolean).
+    """
+
+    return _build_ace_entry("condition", title, display, flags)
+
+
+def expression(title: str, *, display: Optional[str] = None, **flags: Any) -> Callable:
+    """
+    Mark a method as a Fusion expression.
+    """
+
+    return _build_ace_entry("expression", title, display, flags)
+
+
+def property_field(label: str, default: Any = None, description: Optional[str] = None, *, editor: Optional[str] = None, **flags: Any) -> Callable:
+    """
+    Decorate an attribute or method to describe an editor-visible property.
+    For attribute-style properties, decorate a zero-argument method that returns the default value.
+    """
+
+    def decorator(func: Callable) -> Callable:
+        field_def = PropertyField(label=label, default=default, description=description, editor=editor, flags=flags)
+        setattr(func, "__fusion_property__", field_def)
+        return functools.wraps(func)(func)
+
+    return decorator

--- a/fusionpy_sdk/extension.py
+++ b/fusionpy_sdk/extension.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import inspect
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Optional, Type
+
+from .decorators import ACEEntry, PropertyField
+from .runtime import RuntimeBridge
+
+
+@dataclass
+class ExtensionMetadata:
+    """Container describing the ACE table and properties derived from decorators."""
+
+    name: str
+    actions: List[ACEEntry] = field(default_factory=list)
+    conditions: List[ACEEntry] = field(default_factory=list)
+    expressions: List[ACEEntry] = field(default_factory=list)
+    properties: List[PropertyField] = field(default_factory=list)
+
+
+class Extension:
+    """
+    Base class for Python-first Fusion extensions.
+
+    Subclasses can implement lifecycle hooks:
+    * on_create(self)
+    * on_frame(self, delta_time: float)
+    * on_save(self) -> dict
+    * on_load(self, state: dict)
+    """
+
+    runtime: RuntimeBridge
+
+    def __init__(self, runtime: Optional[RuntimeBridge] = None) -> None:
+        self.runtime = runtime or RuntimeBridge()
+
+    @classmethod
+    def collect_metadata(cls: Type["Extension"]) -> ExtensionMetadata:
+        actions: List[ACEEntry] = []
+        conditions: List[ACEEntry] = []
+        expressions: List[ACEEntry] = []
+        properties: List[PropertyField] = []
+
+        for _, member in inspect.getmembers(cls, predicate=inspect.isfunction):
+            ace = getattr(member, "__fusion_ace__", None)
+            if ace:
+                if ace.kind == "action":
+                    actions.append(ace)
+                elif ace.kind == "condition":
+                    conditions.append(ace)
+                elif ace.kind == "expression":
+                    expressions.append(ace)
+            prop = getattr(member, "__fusion_property__", None)
+            if prop:
+                properties.append(prop)
+
+        return ExtensionMetadata(
+            name=cls.__name__,
+            actions=actions,
+            conditions=conditions,
+            expressions=expressions,
+            properties=properties,
+        )
+
+    def on_create(self) -> None:
+        """Lifecycle hook invoked when the extension instance is created."""
+
+    def on_frame(self, delta_time: float) -> None:
+        """Lifecycle hook invoked every Fusion frame."""
+
+    def on_save(self) -> Dict[str, Any]:
+        """Return a serializable object representing extension state."""
+        return {}
+
+    def on_load(self, state: Dict[str, Any]) -> None:
+        """Restore state previously returned by on_save."""
+        _ = state

--- a/fusionpy_sdk/manifest.py
+++ b/fusionpy_sdk/manifest.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+try:
+    import yaml
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    yaml = None
+
+
+REQUIRED_KEYS = {"name", "id", "version", "entrypoint"}
+
+
+@dataclass
+class Manifest:
+    name: str
+    id: str
+    version: str
+    entrypoint: str
+    runtime: Dict[str, Any] = field(default_factory=dict)
+    capabilities: List[str] = field(default_factory=list)
+    actions: List[Dict[str, Any]] = field(default_factory=list)
+    conditions: List[Dict[str, Any]] = field(default_factory=list)
+    expressions: List[Dict[str, Any]] = field(default_factory=list)
+    properties: List[Dict[str, Any]] = field(default_factory=list)
+    resources: Dict[str, Any] = field(default_factory=dict)
+    dependencies: Dict[str, Any] = field(default_factory=dict)
+    sandbox: Dict[str, Any] = field(default_factory=dict)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+def _load_raw_manifest(path: Path) -> Dict[str, Any]:
+    if not path.exists():
+        raise FileNotFoundError(f"Manifest file not found: {path}")
+
+    if path.suffix.lower() in {".yml", ".yaml"}:
+        if yaml is None:
+            raise RuntimeError("PyYAML is required to parse YAML manifests")
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    else:
+        data = json.loads(path.read_text(encoding="utf-8"))
+
+    if not isinstance(data, dict):
+        raise ValueError("Manifest root must be a mapping/dictionary")
+    return data
+
+
+def _validate_required(data: Dict[str, Any]) -> None:
+    missing = REQUIRED_KEYS - data.keys()
+    if missing:
+        raise ValueError(f"Manifest missing required fields: {', '.join(sorted(missing))}")
+    for key in ["name", "id", "version", "entrypoint"]:
+        if not isinstance(data.get(key), str) or not data[key].strip():
+            raise ValueError(f"Manifest field '{key}' must be a non-empty string")
+
+
+def _extract_ace_entries(data: Dict[str, Any], key: str) -> List[Dict[str, Any]]:
+    entries = data.get(key, [])
+    if entries is None:
+        return []
+    if not isinstance(entries, list):
+        raise ValueError(f"Manifest field '{key}' must be a list")
+    for entry in entries:
+        if not isinstance(entry, dict):
+            raise ValueError(f"Entries in '{key}' must be dictionaries")
+        if "name" not in entry or "id" not in entry:
+            raise ValueError(f"Entries in '{key}' must define 'id' and 'name'")
+    return entries
+
+
+def _validate_resources(resources: Dict[str, Any]) -> None:
+    for list_key in ("include", "exclude"):
+        value = resources.get(list_key, [])
+        if value is None:
+            continue
+        if not isinstance(value, list):
+            raise ValueError(f"resources.{list_key} must be a list of paths")
+        if not all(isinstance(item, str) for item in value):
+            raise ValueError(f"resources.{list_key} entries must be strings")
+
+
+def _validate_dependencies(dependencies: Dict[str, Any]) -> None:
+    wheels = dependencies.get("wheels", [])
+    if wheels is None:
+        return
+    if not isinstance(wheels, list) or not all(isinstance(item, str) for item in wheels):
+        raise ValueError("dependencies.wheels must be a list of wheel filenames")
+
+
+def validate_manifest(data: Dict[str, Any]) -> Manifest:
+    """
+    Validate manifest data and return a normalized Manifest object.
+    Raises ValueError when validation fails.
+    """
+
+    _validate_required(data)
+    runtime = data.get("runtime", {})
+    if runtime and not isinstance(runtime, dict):
+        raise ValueError("runtime must be a mapping")
+
+    capabilities = data.get("capabilities", [])
+    if capabilities is None:
+        capabilities = []
+    if not isinstance(capabilities, list) or not all(isinstance(item, str) for item in capabilities):
+        raise ValueError("capabilities must be a list of strings")
+
+    actions = _extract_ace_entries(data, "actions")
+    conditions = _extract_ace_entries(data, "conditions")
+    expressions = _extract_ace_entries(data, "expressions")
+    properties = data.get("properties", [])
+    if properties and not isinstance(properties, list):
+        raise ValueError("properties must be a list")
+
+    resources = data.get("resources", {})
+    if resources and not isinstance(resources, dict):
+        raise ValueError("resources must be a mapping")
+    _validate_resources(resources)
+
+    dependencies = data.get("dependencies", {})
+    if dependencies and not isinstance(dependencies, dict):
+        raise ValueError("dependencies must be a mapping")
+    _validate_dependencies(dependencies)
+
+    sandbox = data.get("sandbox", {})
+    if sandbox and not isinstance(sandbox, dict):
+        raise ValueError("sandbox must be a mapping")
+
+    metadata = data.get("metadata", {})
+    if metadata and not isinstance(metadata, dict):
+        raise ValueError("metadata must be a mapping")
+
+    return Manifest(
+        name=data["name"],
+        id=data["id"],
+        version=data["version"],
+        entrypoint=data["entrypoint"],
+        runtime=runtime or {},
+        capabilities=capabilities,
+        actions=actions,
+        conditions=conditions,
+        expressions=expressions,
+        properties=properties or [],
+        resources=resources or {},
+        dependencies=dependencies or {},
+        sandbox=sandbox or {},
+        metadata=metadata or {},
+    )
+
+
+def load_manifest(path: str | Path) -> Manifest:
+    raw = _load_raw_manifest(Path(path))
+    return validate_manifest(raw)

--- a/fusionpy_sdk/runtime.py
+++ b/fusionpy_sdk/runtime.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Dict
+
+
+class RuntimeBridge:
+    """
+    Placeholder runtime surface that matches Fusion services exposed by the host bridge.
+
+    In production, the host bridge provides concrete implementations wired to Fusion's
+    ABI. During local testing, this stub can be used to simulate debugger output and
+    simple storage access.
+    """
+
+    def __init__(self, resource_root: Path | None = None) -> None:
+        self.log_channel = logging.getLogger("fusionpy.runtime")
+        self.resource_root = resource_root or Path.cwd()
+        self.variables: Dict[str, Any] = {}
+
+    def log(self, message: str, level: int = logging.INFO) -> None:
+        self.log_channel.log(level, message)
+
+    def get_resource(self, relative_path: str) -> Path:
+        candidate = self.resource_root / relative_path
+        if not candidate.exists():
+            raise FileNotFoundError(f"Resource '{relative_path}' not found at {candidate}")
+        return candidate
+
+    def check_overlap(self, x: int, y: int) -> bool:
+        """
+        Placeholder for collision/overlap checks against the Fusion scene.
+        The host bridge replaces this with engine-backed logic.
+        """
+
+        self.log(f"Simulated overlap check at ({x}, {y})", logging.DEBUG)
+        return False

--- a/fusionpy_sdk/scaffold.py
+++ b/fusionpy_sdk/scaffold.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+
+TEMPLATE_MANIFEST = """\
+name: {name}
+id: {identifier}
+version: 0.1.0
+entrypoint: {module}.MyExtension
+runtime:
+  fusion_versions: ["2.5"]
+  python: "3.11"
+capabilities:
+  - filesystem
+actions:
+  - id: show_greeting
+    name: Show greeting
+    parameters:
+      - name: target
+        type: string
+conditions:
+  - id: player_in_area
+    name: Player in area
+expressions:
+  - id: get_score
+    name: Get score
+properties:
+  - id: greeting
+    label: Greeting
+    type: string
+resources:
+  include:
+    - assets/**
+dependencies:
+  wheels: []
+sandbox:
+  mode: venv
+"""
+
+
+TEMPLATE_EXTENSION = '''\
+from fusionpy_sdk import Extension, action, condition, expression, property_field
+
+
+class MyExtension(Extension):
+    @property_field(label="Greeting", default="Hello Fusion devs!")
+    def greeting(self):
+        return "Hello Fusion devs!"
+
+    @action("Show greeting")
+    def show(self, target: str = "Debugger"):
+        self.runtime.log(f"{self.greeting} (target: {target})")
+
+    @condition("Player in area")
+    def player_in_area(self, x: int, y: int) -> bool:
+        return self.runtime.check_overlap(x, y)
+
+    @expression("Get score")
+    def get_score(self) -> int:
+        return int(self.runtime.variables.get("score", 0))
+
+    def on_create(self):
+        self.runtime.log("MyExtension created", level=20)
+'''
+
+
+def init_extension(name: str, target_dir: Path) -> None:
+    target_dir.mkdir(parents=True, exist_ok=True)
+    identifier = name.lower().replace(" ", "_")
+    module_name = identifier
+    manifest_path = target_dir / "fusion_extension.yml"
+    module_path = target_dir / f"{module_name}.py"
+    assets_dir = target_dir / "assets"
+    assets_dir.mkdir(exist_ok=True)
+
+    if not manifest_path.exists():
+        manifest_path.write_text(TEMPLATE_MANIFEST.format(name=name, identifier=identifier, module=module_name), encoding="utf-8")
+
+    if not module_path.exists():
+        module_path.write_text(TEMPLATE_EXTENSION, encoding="utf-8")


### PR DESCRIPTION
## Summary
- add a fusionpy_sdk prototype with decorators, manifest validation, scaffolding, and build helpers for Python-based Fusion extensions
- document the architecture and workflow in docs/fusionpy-sdk.md and README.md
- provide a CLI with init/validate/build/run/publish commands and bundle resources/bytecode into distributable archives

## Testing
- python -m fusionpy_sdk.cli --help


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69438102ba88832c951559e2a5208e22)