### PR TITLE
Complete MMFI runtime helpers

### DIFF
--- a/DarkEdif/DarkEdif Template/Actions.cpp
+++ b/DarkEdif/DarkEdif Template/Actions.cpp
@@ -1,9 +1,43 @@
 #include "Common.hpp"
 
-void Extension::ActionExample(int ExampleParameter)
+void Extension::ResetContext()
 {
+	dukCtx.reset();
+	InitialiseContext();
 }
 
-void Extension::SecondActionExample()
+void Extension::RunJavaScript(const TCHAR * code)
 {
+	if (!code)
+		return;
+	EvalJavaScript(code);
+}
+
+void Extension::CallFunctionExpression(const TCHAR * callText)
+{
+	if (!callText)
+		return;
+	std::tstring wrapped = _T("(function(){ return ");
+	wrapped += callText;
+	wrapped += _T("; })();");
+	EvalJavaScript(wrapped);
+}
+
+void Extension::RebuildMMFI()
+{
+        if (!dukCtx)
+                InitialiseContext();
+        else
+                RegisterMMFIHelpers();
+}
+
+void Extension::ProbeClasses()
+{
+        if (!dukCtx)
+                InitialiseContext();
+
+        if (!dukCtx)
+                return;
+
+        ProbeClassSupport();
 }

--- a/DarkEdif/DarkEdif Template/Conditions.cpp
+++ b/DarkEdif/DarkEdif Template/Conditions.cpp
@@ -1,6 +1,9 @@
 #include "Common.hpp"
 
-bool Extension::AreTwoNumbersEqual(int First, int Second)
+bool Extension::OnJavaScriptError()
 {
-	return First == Second;
+	if (!pendingErrorEvent)
+		return false;
+	pendingErrorEvent = false;
+	return true;
 }

--- a/DarkEdif/DarkEdif Template/DarkEdif Template.Shared.vcxitems
+++ b/DarkEdif/DarkEdif Template/DarkEdif Template.Shared.vcxitems
@@ -7,9 +7,9 @@
     <ItemsProjectName>DarkEdif Template.Shared</ItemsProjectName>
   </PropertyGroup>
   <ItemDefinitionGroup>
-    <ClCompile>
-      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(MSBuildThisFileDirectory.TrimEnd('/\'))</AdditionalIncludeDirectories>
-    </ClCompile>
+	<ClCompile>
+		<AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(MSBuildThisFileDirectory.TrimEnd('/\\'));$(MSBuildThisFileDirectory)..\..\duktape-2.7.0\src</AdditionalIncludeDirectories>
+	</ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ProjectCapability Include="SourceItemsFromImports" />
@@ -21,8 +21,9 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\Inc\Shared\Strings.hpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\Inc\Shared\json.hpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\Inc\Shared\NonWindowsDefines.hpp" />
-    <ClInclude Include="$(MSBuildThisFileDirectory)..\Inc\Shared\ObjectSelection.hpp" />
-    <ClInclude Include="$(MSBuildThisFileDirectory)..\Inc\Shared\SurfaceMultiPlat.hpp" />
+	<ClInclude Include="$(MSBuildThisFileDirectory)..\Inc\Shared\ObjectSelection.hpp" />
+	<ClInclude Include="$(MSBuildThisFileDirectory)..\Inc\Shared\SurfaceMultiPlat.hpp" />
+	<ClInclude Include="$(MSBuildThisFileDirectory)..\..\duktape-2.7.0\src\duktape.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)Common.hpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)Extension.hpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)Resource.h" />
@@ -32,9 +33,10 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\Lib\Shared\Edif.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\Lib\Shared\Edif.General.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\Lib\Shared\Edif.Runtime.cpp" />
-    <ClCompile Include="$(MSBuildThisFileDirectory)..\Lib\Shared\json.cpp" />
-    <ClCompile Include="$(MSBuildThisFileDirectory)..\Lib\Shared\ObjectSelection.cpp" />
-    <ClCompile Include="$(MSBuildThisFileDirectory)..\Lib\Shared\SurfaceMultiPlat.cpp" />
+	<ClCompile Include="$(MSBuildThisFileDirectory)..\Lib\Shared\json.cpp" />
+	<ClCompile Include="$(MSBuildThisFileDirectory)..\Lib\Shared\ObjectSelection.cpp" />
+	<ClCompile Include="$(MSBuildThisFileDirectory)..\Lib\Shared\SurfaceMultiPlat.cpp" />
+	<ClCompile Include="$(MSBuildThisFileDirectory)..\..\duktape-2.7.0\src\duktape.c" />
     <ClCompile Include="$(MSBuildThisFileDirectory)Actions.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)Conditions.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)Expressions.cpp" />

--- a/DarkEdif/DarkEdif Template/DarkExt.json
+++ b/DarkEdif/DarkEdif Template/DarkExt.json
@@ -1,268 +1,332 @@
-﻿{
-	// 4-character identifer that uniquely identifies your extension.
-	// Can be letters, numbers, or punctuation, but must be 4 ASCII characters.
-	"Identifier": "EXMP",
-	"Dependencies": "",
-	"UK English": {
-		"About": {
-			"Name": "DarkEdif Template",
-			"Author": "Your Name",
-			"Comment": "A sentence or two to describe your extension",
-			"Copyright": "Copyright \u00A9 2025 by Your Name",
-			"Help": "Help/Example.chm",
-			"URL": "https://www.example.com/"
-		},
-		"ActionMenu": [
-			[ 0, "Action Example" ],
-			"---",
-			[ "Sub Menu",
-				[ 1, "Second Action Example" ]
-			]
-		],
-		"ConditionMenu": [
-			[ 0, "Are two numbers equal?" ]
-		],
-		"ExpressionMenu": [
-			[ 0, "Add two numbers" ],
-			[ 1, "Hello world" ]
-		],
-		"Actions": [
-			{
-				"Title": "Action Example with parameter %0",
-				"Parameters": [
-					[ "Integer", "Example Parameter" ]
-				]
-			},
-			{
-				"Title": "Second Action Example"
-			}
-		],
-		"Conditions": [
-			{
-				"Title": "%o : Are %0 and %1 equal?",
-				"Triggered": false,
-				"Parameters": [
-					[ "Integer", "First number" ],
-					[ "Integer", "Second number" ]
-				]
-			}
-		],
-		"Expressions": [
-			{
-				"Title": "Add(",
-				"Returns": "Integer",
-				"Parameters": [
-					[ "Integer", "First number" ],
-					[ "Integer", "Second number" ]
-				]
-			},
-			{
-				"Title": "HelloWorld$(",
-				"Returns": "Text"
-			}
-		],
-		"Properties": [
-			{
-				"Title": "Folder of props",
-				"Info": "Folder information",
-				"Type": "Folder"
-			},
-			{
-				"Title": "Checkbox within folder",
-				"Info": "Should be bold text.",
-				"Type": "Checkbox",
-				"DefaultState": true, // or false
-				"Bold": true
-			},
-			{
-				"Type": "FolderEnd"
-			},
-			{
-				"Title": "Static text 1",
-				"Info": "Blank text",
-				"Type": "Text",
-				"DefaultState": "Static text, default state. Or default text."
-			},
-			{
-				"Title": "Static text 2",
-				"Info": "Blank text, bold",
-				"Type": "Text",
-				"DefaultState": "Bolded static text",
-				"Bold": true
-			},
-			{
-				"Title": "Editable 3",
-				"Info": "Shouldn't be bold.",
-				"Type": "Edit button",
-				"DefaultState": "Button text"
-			},
-			{
-				"Title": "Editable 4",
-				"Info": "Fusion ignores the bold setting.",
-				"Type": "Edit button",
-				"DefaultState": "Bolded button text",
-				"Bold": true
-			},
-			{
-				"Title": "Editable 5",
-				"Info": "Still set to bold, and bold is ignored.",
-				"DefaultState": "Default text",
-				"Type": "Editbox String",
-				"Bold": true
-			},
-			{
-				"Title": "Editable 6",
-				"Info": "Force uppercase on the input text.",
-				"Type": "Editbox String",
-				"DefaultState": "Default text, made uppercase",
-				"Case": "Upper"
-			},
-			{
-				"Title": "Editable 7",
-				"Info": "This one should be limited to 25 characters.",
-				"Type": "Editbox String",
-				"DefaultState": "Default text, made lowercase",
-				"Case": "Lower",
-				"MaxLength": 25
-			},
-			{
-				"Title": "Editable 8",
-				"Info": "Number limited between 20 and 25",
-				"Type": "Editbox Number",
-				"DefaultState": 21,
-				"Minimum": 20,
-				"Maximum": 25
-			}
-		]
-	},
-	"French": {
-		"About": {
-			"Name": "Exemple objet",
-			"Author": "Votre Nom",
-			"Copyright": "Copyright \u00A9 2022 par Votre Nom",
-			"Comment": "Une ou deux phrases pour décrire votre poste",
-			"Help": "Help/Example.chm",
-			"URL": "http://www.example.com/"
-		},
-		"ActionMenu": [
-			[ 0, "Exemple d'action" ],
-			"---",
-			[ "Sub Menu",
-				[ 1, "Exemple deuxième action" ]
-			]
-		],
-		"ConditionMenu": [
-			[ 0, "Sont deux nombres égaux?" ]
-		],
-		"ExpressionMenu": [
-			[ 0, "Ajouter deux nombres" ],
-			[ 1, "Bonjour monde" ]
-		],
-		"Actions": [
-			{
-				"Title": "Exemple d'action avec le paramètre %0",
-				"Parameters": [
-					[ "Integer", "Paramètre exemple" ]
-				]
-			},
-			{
-				"Title": "Exemple deuxième action"
-			}
-		],
-		"Conditions": [
-			{
-				"Title": "%o : Sont de %0 et %1 égale?",
-				"Triggered": false,
-				"Parameters": [
-					[ "Integer", "Premier numéro" ],
-					[ "Integer", "Deuxième numéro" ]
-				]
-			}
-		],
-		"Expressions": [
-			{
-				"Title": "Adherer(",
-				"Returns": "Integer",
-				"Parameters": [
-					[ "Integer", "Premier numéro" ],
-					[ "Integer", "Deuxième numéro" ]
-				]
-			},
-			{
-				"Title": "BonjourMonde$(",
-				"Returns": "Text"
-			}
-		],
-		"Properties": [
-			{
-				"Title": "Folder",
-				"Info": "Folder d'information",
-				"Type": "Folder"
-			},
-				{
-					"Title": "Case à cocher dans le dossier",
-					"Info": "oui, il faut faire preuve d'audace.",
-					"Type": "Checkbox",
-					"Bold": true,
-					"DefaultState": true
-				},
-			{
-				"Type": "FolderEnd"
-			},
-			{
-				"Title": "Texte statique 1",
-				"Info": "Texte vide",
-				"Type": "Text"
-			},
-			{
-				"Title": "Texte statique 2",
-				"Info": "Texte vide, en caractères gras",
-				"Type": "Text",
-				"Bold": true
-			},
-			{
-				"Title": "Éditable 3",
-				"Info": "Ouais, il ne devrait pas faire preuve d'audace.",
-				"Type": "Edit button",
-				"DefaultState": "Bouton"
-			},
-			{
-				"Title": "Éditable 4",
-				"Info": "Ouais, il est très gras.",
-				"Type": "Edit button",
-				"DefaultState": "Bouton texte",
-				"Bold": true
-			},
-			{
-				"Title": "Éditable 5",
-				"Info": "Régulière chaîne de boîte d'édition.",
-				"Type": "Editbox String"
-			},
-			{
-				"Title": "Éditable 6",
-				"Info": "Celui-ci devrait obliger les majuscules.",
-				"Type": "Editbox String",
-				"Case": "Upper"
-			},
-			{
-				"Title": "Éditable 7",
-				"Info": "Celui-ci devrait être limité à 25 caractères.",
-				"Type": "Editbox String",
-				"Case": "Lower",
-				"MaxLength": 25
-			},
-			{
-				"Title": "Éditable 8",
-				"Info": "Celui-ci devrait être limité entre 20 et 25.",
-				"Type": "Editbox Number",
-				"Maximum": 25,
-				"Minimum": 20
-			}
-		]
-	}
-	/*
-	"German":
-	{},
-	"Japanese":
-	{}*/
+{
+        "Identifier": "DKJS",
+        "Dependencies": "",
+        "UK English": {
+                "About": {
+                        "Name": "Duktape MMFI",
+                        "Author": "DarkEDIF Team",
+                        "Comment": "Duktape 2.7.0 scripting with MMFI-style helpers",
+                        "Copyright": "Copyright \u00a9 2025",
+                        "Help": "",
+                        "URL": "https://duktape.org/"
+                },
+                "ActionMenu": [
+                        [
+                                0,
+                                "Reset Duktape context"
+                        ],
+                        [
+                                1,
+                                "Run JavaScript snippet"
+                        ],
+                        [
+                                2,
+                                "Call JS function expression"
+                        ],
+                        [
+                                3,
+                                "Rebuild MMFI bindings"
+                        ],
+                        [
+                                4,
+                                "Probe class support"
+                        ]
+                ],
+                "ConditionMenu": [
+                        [
+                                0,
+                                "On JavaScript error"
+                        ]
+                ],
+                "ExpressionMenu": [
+                        [
+                                0,
+                                "LastResult$"
+                        ],
+                        [
+                                1,
+                                "LastNumber"
+                        ],
+                        [
+                                2,
+                                "LastError$"
+                        ],
+                        [
+                                3,
+                                "ClassSupport"
+                        ],
+                        [
+                                4,
+                                "CurrentFrame"
+                        ],
+                        [
+                                5,
+                                "ObjectCount"
+                        ],
+                        [
+                                6,
+                                "LastResultType"
+                        ],
+                        [
+                                7,
+                                "LastBoolean"
+                        ]
+                ],
+                "Actions": [
+                        {
+                                "Title": "Reset Duktape context"
+                        },
+                        {
+                                "Title": "Run JavaScript %0",
+                                "Parameters": [
+                                        [
+                                                "Text",
+                                                "JavaScript code"
+                                        ]
+                                ]
+                        },
+                        {
+                                "Title": "Call JS function expression %0",
+                                "Parameters": [
+                                        [
+                                                "Text",
+                                                "Function call including arguments"
+                                        ]
+                                ]
+                        },
+                        {
+                                "Title": "Rebuild MMFI bindings"
+                        },
+                        {
+                                "Title": "Probe class support",
+                                "Info": "Re-run the ES6 class syntax test on demand"
+                        }
+                ],
+                "Conditions": [
+                        {
+                                "Title": "On JavaScript error",
+                                "Triggered": true
+                        }
+                ],
+                "Expressions": [
+                        {
+                                "Title": "LastResult$(",
+                                "Returns": "Text"
+                        },
+                        {
+                                "Title": "LastNumber(",
+                                "Returns": "Float"
+                        },
+                        {
+                                "Title": "LastError$(",
+                                "Returns": "Text"
+                        },
+                        {
+                                "Title": "ClassSupport(",
+                                "Returns": "Integer"
+                        },
+                        {
+                                "Title": "CurrentFrame(",
+                                "Returns": "Integer"
+                        },
+                        {
+                                "Title": "ObjectCount(",
+                                "Returns": "Integer"
+                        },
+                        {
+                                "Title": "LastResultType(",
+                                "Info": "Returns 1 for number, 2 for boolean, 3 for string, 0 otherwise",
+                                "Returns": "Integer"
+                        },
+                        {
+                                "Title": "LastBoolean(",
+                                "Info": "Returns 1 if the last result was a boolean true, 0 otherwise",
+                                "Returns": "Integer"
+                        }
+                ],
+                "Properties": [
+                        {
+                                "Title": "Bootstrap code",
+                                "Info": "JavaScript executed when the context is created",
+                                "Type": "Editbox String",
+                                "DefaultState": ""
+                        },
+                        {
+                                "Title": "Expose MMFI on start",
+                                "Info": "Automatically inject the mmf helper object into Duktape",
+                                "Type": "Checkbox",
+                                "DefaultState": true
+                        },
+                        {
+                                "Title": "Probe class support on start",
+                                "Info": "Run a small ES6 class probe after creating the context",
+                                "Type": "Checkbox",
+                                "DefaultState": true
+                        }
+                ]
+        },
+        "French": {
+                "About": {
+                        "Name": "Duktape MMFI",
+                        "Author": "DarkEDIF Team",
+                        "Copyright": "Copyright \u00a9 2025",
+                        "Comment": "Duktape 2.7.0 avec aides MMFI",
+                        "Help": "",
+                        "URL": "https://duktape.org/"
+                },
+                "ActionMenu": [
+                        [
+                                0,
+                                "R\u00e9initialiser le contexte"
+                        ],
+                        [
+                                1,
+                                "Ex\u00e9cuter du JavaScript"
+                        ],
+                        [
+                                2,
+                                "Appeler une fonction JS"
+                        ],
+                        [
+                                3,
+                                "Reconstruire les liaisons MMFI"
+                        ],
+                        [
+                                4,
+                                "Tester les classes maintenant"
+                        ]
+                ],
+                "ConditionMenu": [
+                        [
+                                0,
+                                "Sur erreur JavaScript"
+                        ]
+                ],
+                "ExpressionMenu": [
+                        [
+                                0,
+                                "DernierR\u00e9sultat$"
+                        ],
+                        [
+                                1,
+                                "DernierNombre"
+                        ],
+                        [
+                                2,
+                                "Derni\u00e8reErreur$"
+                        ],
+                        [
+                                3,
+                                "SupportClasse"
+                        ],
+                        [
+                                4,
+                                "CadreActuel"
+                        ],
+                        [
+                                5,
+                                "NombreObjets"
+                        ],
+                        [
+                                6,
+                                "TypeDernierR\u00e9sultat"
+                        ],
+                        [
+                                7,
+                                "DernierBool"
+                        ]
+                ],
+                "Actions": [
+                        {
+                                "Title": "R\u00e9initialiser le contexte Duktape"
+                        },
+                        {
+                                "Title": "Ex\u00e9cuter le JavaScript %0",
+                                "Parameters": [
+                                        [
+                                                "Text",
+                                                "Code JavaScript"
+                                        ]
+                                ]
+                        },
+                        {
+                                "Title": "Appeler l'expression de fonction JS %0",
+                                "Parameters": [
+                                        [
+                                                "Text",
+                                                "Appel de fonction avec arguments"
+                                        ]
+                                ]
+                        },
+                        {
+                                "Title": "Reconstruire les liaisons MMFI"
+                        },
+                        {
+                                "Title": "Tester les classes maintenant",
+                                "Info": "Relance le test de syntaxe de classe ES6 \u00e0 la demande"
+                        }
+                ],
+                "Conditions": [
+                        {
+                                "Title": "Sur erreur JavaScript",
+                                "Triggered": true
+                        }
+                ],
+                "Expressions": [
+                        {
+                                "Title": "DernierR\u00e9sultat$(",
+                                "Returns": "Text"
+                        },
+                        {
+                                "Title": "DernierNombre(",
+                                "Returns": "Float"
+                        },
+                        {
+                                "Title": "Derni\u00e8reErreur$(",
+                                "Returns": "Text"
+                        },
+                        {
+                                "Title": "SupportClasse(",
+                                "Returns": "Integer"
+                        },
+                        {
+                                "Title": "CadreActuel(",
+                                "Returns": "Integer"
+                        },
+                        {
+                                "Title": "NombreObjets(",
+                                "Returns": "Integer"
+                        },
+                        {
+                                "Title": "TypeDernierR\u00e9sultat(",
+                                "Info": "Renvoie 1 pour nombre, 2 pour bool\u00e9en, 3 pour cha\u00eene, 0 sinon",
+                                "Returns": "Integer"
+                        },
+                        {
+                                "Title": "DernierBool(",
+                                "Info": "Renvoie 1 si le dernier r\u00e9sultat \u00e9tait true, 0 sinon",
+                                "Returns": "Integer"
+                        }
+                ],
+                "Properties": [
+                        {
+                                "Title": "Code d'initialisation",
+                                "Info": "JavaScript ex\u00e9cut\u00e9 \u00e0 la cr\u00e9ation du contexte",
+                                "Type": "Editbox String",
+                                "DefaultState": ""
+                        },
+                        {
+                                "Title": "Exposer MMFI au d\u00e9marrage",
+                                "Info": "Injecter automatiquement l'objet mmf",
+                                "Type": "Checkbox",
+                                "DefaultState": true
+                        },
+                        {
+                                "Title": "Tester les classes au d\u00e9marrage",
+                                "Info": "Lancer un test de syntaxe class apr\u00e8s la cr\u00e9ation du contexte",
+                                "Type": "Checkbox",
+                                "DefaultState": true
+                        }
+                ]
+        }
 }

--- a/DarkEdif/DarkEdif Template/Expressions.cpp
+++ b/DarkEdif/DarkEdif Template/Expressions.cpp
@@ -1,11 +1,41 @@
 #include "Common.hpp"
 
-int Extension::Add(int First, int Second)
+const TCHAR * Extension::LastResult()
 {
-	return First + Second;
+	return Runtime.CopyString(lastResultText.c_str());
 }
 
-const TCHAR * Extension::HelloWorld()
+double Extension::LastNumber()
 {
-	return Runtime.CopyString(_T("Hello world!"));
+	return hasNumericResult ? lastResultNumber : 0.0;
+}
+
+const TCHAR * Extension::LastError()
+{
+	return Runtime.CopyString(lastError.c_str());
+}
+
+int Extension::ClassSupport()
+{
+	return classSyntaxSupported ? 1 : 0;
+}
+
+int Extension::CurrentFrameIndex()
+{
+	return Runtime.GetCurrentFusionFrameNumber();
+}
+
+int Extension::ObjectCount()
+{
+        return rhPtr ? static_cast<int>(rhPtr->get_NObjects()) : 0;
+}
+
+int Extension::LastResultType()
+{
+        return static_cast<int>(lastResultKind);
+}
+
+int Extension::LastBoolean()
+{
+        return (lastResultKind == ResultKind::Boolean && lastResultBoolean) ? 1 : 0;
 }

--- a/DarkEdif/DarkEdif Template/Extension.cpp
+++ b/DarkEdif/DarkEdif Template/Extension.cpp
@@ -1,10 +1,5 @@
 #include "Common.hpp"
-#include <iomanip>
-using namespace std::chrono_literals;
-
-///
-/// EXTENSION CONSTRUCTOR/DESTRUCTOR
-///
+#include <cmath>
 
 #ifdef _WIN32
 Extension::Extension(RunObject* const _rdPtr, const EDITDATA* const edPtr, const CreateObjectInfo* const cobPtr) :
@@ -18,219 +13,677 @@ Extension::Extension(const EDITDATA* const edPtr, void* const objCExtPtr, const 
 	objCExtPtr(objCExtPtr), Runtime(this, objCExtPtr), FusionDebugger(this)
 #endif
 {
-	/*
-		Link all your action/condition/expression functions to their IDs to match the
-		IDs in the JSON here
-	*/
+        LinkAction(0, ResetContext);
+        LinkAction(1, RunJavaScript);
+        LinkAction(2, CallFunctionExpression);
+        LinkAction(3, RebuildMMFI);
+        LinkAction(4, ProbeClasses);
 
-	LinkAction(0, ActionExample);
-	LinkAction(1, SecondActionExample);
+	LinkCondition(0, OnJavaScriptError);
 
-	LinkCondition(0, AreTwoNumbersEqual);
+	LinkExpression(0, LastResult);
+	LinkExpression(1, LastNumber);
+	LinkExpression(2, LastError);
+        LinkExpression(3, ClassSupport);
+        LinkExpression(4, CurrentFrameIndex);
+        LinkExpression(5, ObjectCount);
+        LinkExpression(6, LastResultType);
+        LinkExpression(7, LastBoolean);
 
-	LinkExpression(0, Add);
-	LinkExpression(1, HelloWorld);
+	exposeMMFIOnStart = edPtr->Props.IsPropChecked(_T("Expose MMFI on start"));
+	probeClassesOnStart = edPtr->Props.IsPropChecked(_T("Probe class support on start"));
+	bootstrapCode = edPtr->Props.GetPropertyStr(_T("Bootstrap code"));
 
-	/*
-		This is where you'd do anything you'd do in CreateRunObject in the original SDK
-
-		It's the only place you'll get access to edPtr at runtime, so you should transfer
-		anything from edPtr to the extension class here.
-
-	*/
-
-	// Don't use "this" inside these lambda functions, always ext.
-	// There can be nothing in the [] section of the lambda.
-	// If you're not sure about lambdas, you can remove this debugger stuff without any side effects;
-	// it's just an example of how to use the debugger. You can view it in Fusion itself to see.
 	FusionDebugger.AddItemToDebugger(
-		// reader function for your debug item
-		[](Extension *ext, std::tstring &writeTo) {
-			writeTo = _T("My text is: ") + ext->exampleDebuggerTextItem;
+		[](Extension* ext, std::tstring& writeTo) {
+			writeTo = _T("Last JS result: ") + ext->lastResultText;
 		},
-		// writer function (can be null if you don't want user to be able to edit it in debugger)
-		[](Extension *ext, std::tstring &newText) {
-			ext->exampleDebuggerTextItem = newText;
-			return true; // accept the changes
-		}, 500, NULL
-	);
+		nullptr, 500, nullptr);
 
-	// Read object DarkEdif properties; you can pass property name, or property index
-	// This will work on all platforms the same way.
-	// See edPtr->Props functions.
-	bool checkboxWithinFolder = edPtr->Props.IsPropChecked("Checkbox within folder"sv);
-	std::tstring editable6Text = edPtr->Props.GetPropertyStr("Editable 6"sv);
+	FusionDebugger.AddItemToDebugger(
+		[](Extension* ext, std::tstring& writeTo) {
+			writeTo = ext->lastError.empty() ? _T("No errors") : (_T("Error: ") + ext->lastError);
+		},
+		nullptr, 500, nullptr);
 
-	// These lines do nothing, but prevent the compiler warning the variables are unused
-	(void)checkboxWithinFolder;
-	(void)editable6Text;
-
-#if TEXT_OEFLAG_EXTENSION
-	// Copy from edittime data into runtime data
-	font.CopyFromEditFont(this, edPtr->font);
-
-	// Set Runtime.fontChangedFunc to trigger a function if the runtime
-	// changes your ext's font via the built-in font actions
-	Runtime.fontChangedFunc = &Extension::OnFontChanged;
-#endif
-
-#if DARKEDIF_DISPLAY_TYPE == DARKEDIF_DISPLAY_SIMPLE
-	Runtime.SetSurfaceWithSize(edPtr->objSize.width, edPtr->objSize.height);
-	// surf is already constructed
-	// To start, let's make the image a solid blue fill
-	surf->FillImageWith(DarkEdif::SurfaceFill::Solid(DarkEdif::ColorRGB(0, 0, 127)));
-#endif
+	InitialiseContext();
 }
 
 Extension::~Extension()
 {
-
 }
 
-// Runs every tick of Fusion's runtime, can be toggled off and back on
 REFLAG Extension::Handle()
 {
-	/*	If your extension won't draw to the window, but it still needs
-		to do something every Fusion loop, use:
-			return REFLAG::NONE;
-
-		If you don't need to do something in Handle anymore, use:
-			return REFLAG::ONE_SHOT;
-		...you can later re-enable Handle with Runtime.Rehandle(),
-		but don't use one-shot with a displaying ext.
-
-		If you're drawing with simple display, use:
-			return surf->GetAndResetAltered() ? REFLAG::DISPLAY : REFLAG::NONE;
-
-		If you're drawing manually, use rdPtr->get_roc()->get_changed(),
-		and potentially your surfaces GetAndResetAltered(), to decide
-		what REFLAG to return.
-		DarkEdif expects you to do manual drawing in Extension::Display()
-		and other funcs.
-	*/
-
-#if DARKEDIF_DISPLAY_TYPE >= DARKEDIF_DISPLAY_SIMPLE
-	// Example variables for showing how display can be modified.
-	// These values should be in your Extension, not static; this is just a brief demo,
-	// to show how to easily time your ext's display changes.
-	// Display does not have to be done in Handle, but you do need to return
-	// REFLAG::DISPLAY here and/or do rdPtr->get_roc()->set_changed(true) when display is changed.
-	static std::chrono::steady_clock clock;
-	static decltype(clock)::time_point nextTick;
-	static const std::uint32_t colors[] = {
-		DarkEdif::ColorRGB(128, 0, 0), DarkEdif::ColorRGB(168, 157, 50),
-		DarkEdif::ColorRGB(50, 168, 64), DarkEdif::ColorRGB(50, 54, 168)
-	};
-	static std::size_t colorIndex = 0;
-	if (nextTick < clock.now())
-	{
-		nextTick = clock.now() + 200ms;
-		if (++colorIndex >= std::size(colors))
-			colorIndex = 0;
-		surf->FillImageWith(DarkEdif::SurfaceFill::Solid(colors[colorIndex]));
-	}
-	return surf->GetAndResetAltered() ? REFLAG::DISPLAY : REFLAG::NONE;
-#endif
-
-	// Will not be called next event tick
 	return REFLAG::ONE_SHOT;
 }
 
-#if PAUSABLE_EXTENSION
-// Called when Fusion runtime is pausing - not just the F3 pause dialog
-void Extension::FusionRuntimePaused()
-{
-
-}
-
-// Called when Fusion runtime is resuming after a pause
-void Extension::FusionRuntimeContinued()
-{
-
-}
-#endif // PAUSABLE_EXTENSION
-
-#if TEXT_OEFLAG_EXTENSION
-/* Triggered when the runtime changes the font name or size via built-in actions
- * @param colorEdit If true, font color was edited. If false, the font typeface was.
- * @param rect		If not null, contains a hint as to what size the object should be.
- *					This is based on differences between original font size and current one.
- *					You can ignore this hint, but it indicates you may want to call
- *					rdPtr->get_roc()->SetSize(). */
-void Extension::OnFontChanged(bool colorEdit, DarkEdif::Rect * rect)
-{
-	// Prevent warnings about unused variables
-	(void)colorEdit;
-	(void)rect;
-
-	// We could call Runtime.Redraw() to redraw ext immediately,
-	// but we'll be patient and wait for next event tick
-	rdPtr->get_roc()->set_changed(true);
-	Runtime.Rehandle();
-}
-
-#endif
-
-#if DARKEDIF_DISPLAY_TYPE == DARKEDIF_DISPLAY_MANUAL
-
-void Extension::Display()
-{
-	// You should manually draw the surface(s) here.
-	// Surface::BlitToFrameWithExtEffects will let you draw with the ext's sprites/X/Y accounted for,
-	// but note you should also manage the collision mask in GetCollisionMask().
-	// If you have a single surface, and don't want simple drawing, use the GetDisplaySurface().
-	//
-	//surf->BlitToFrameWithExtEffects(this, Point { x offset, y offset });
-}
-
-
-void Extension::GetZoneInfos()
-{
-	LOGI(_T("##### Extension::GetZoneInfos() called.\n"));
-	// You can safely do nothing here. Some extensions do:
-	// rdPtr->get_rHo()->set_ImgWidth()/set_ImgHeight()
-	// but it is done automatically in CF2.5, so shouldn't be necessary.
-}
-
-DarkEdif::Surface * Extension::GetDisplaySurface()
-{
-	// Old style MMF2 fade-in/fade-out transistions requires this function,
-	// Auto-rendering of Sprite effects (alpha coeff etc) will be applied by returning a surface here.
-	// If you have multiple surfaces, you should can return null here and draw them yourself.
-	// If you return null here, Display() will be called instead.
-	return nullptr;
-}
-DarkEdif::CollisionMask * Extension::GetCollisionMask(std::uint32_t flags)
-{
-	// If your ext supports fine collision, you should return the collision mask corresponding to
-	// which pixels have collision and which don't. DarkEdif::Surface can generate collision masks,
-	// but it can be computationally expensive.
-	// If your ext uses only box collision, DE will detect that and never call this function.
-	(void)flags;
-
-	return nullptr;
-}
-
-#endif // DARKEDIF_DISPLAY_MANUAL
-
-// These are called if there's no function linked to an ID
-
 void Extension::UnlinkedAction(int ID)
 {
-	DarkEdif::MsgBox::Error(_T("Extension::UnlinkedAction() called"), _T("Running a fallback for action ID %d. Make sure you ran LinkAction()."), ID);
+	DarkEdif::MsgBox::Error(_T("Action %i not linked!"), ID);
 }
 
 long Extension::UnlinkedCondition(int ID)
 {
-	DarkEdif::MsgBox::Error(_T("Extension::UnlinkedCondition() called"), _T("Running a fallback for condition ID %d. Make sure you ran LinkCondition()."), ID);
-	return 0;
+	DarkEdif::MsgBox::Error(_T("Condition %i not linked!"), ID);
+	return false;
 }
 
 long Extension::UnlinkedExpression(int ID)
 {
-	DarkEdif::MsgBox::Error(_T("Extension::UnlinkedExpression() called"), _T("Running a fallback for expression ID %d. Make sure you ran LinkExpression()."), ID);
-	// Unlinked A/C/E is fatal error, but try not to return null string and definitely crash it
-	if ((std::size_t)ID < Edif::SDK->ExpressionInfos.size() && Edif::SDK->ExpressionInfos[ID]->Flags.ef == ExpReturnType::String)
-		return (long)Runtime.CopyString(_T(""));
+	DarkEdif::MsgBox::Error(_T("Expression %i not linked!"), ID);
 	return 0;
+}
+
+void Extension::InitialiseContext()
+{
+        lastError.clear();
+        lastResultText.clear();
+        hasNumericResult = false;
+        lastResultBoolean = false;
+        lastResultKind = ResultKind::None;
+        pendingErrorEvent = false;
+        classSyntaxSupported = false;
+
+	dukCtx.reset(duk_create_heap_default());
+	if (!dukCtx)
+	{
+		RecordError(_T("Failed to create Duktape heap."), true);
+		return;
+	}
+
+	duk_push_heap_stash(dukCtx.get());
+	duk_push_pointer(dukCtx.get(), this);
+	duk_put_prop_string(dukCtx.get(), -2, "ext_ptr");
+	duk_pop(dukCtx.get());
+
+	if (exposeMMFIOnStart)
+		RegisterMMFIHelpers();
+
+	if (probeClassesOnStart)
+		ProbeClassSupport();
+
+	if (!bootstrapCode.empty())
+		EvalJavaScript(bootstrapCode, false);
+}
+
+void Extension::RegisterMMFIHelpers()
+{
+        if (!dukCtx)
+                return;
+
+        duk_push_global_object(dukCtx.get());
+        duk_push_object(dukCtx.get());
+
+        auto defineGetter = [](duk_context* ctx, const char* name, duk_c_function getter)
+        {
+                duk_push_string(ctx, name);
+                duk_push_c_function(ctx, getter, 0);
+                duk_def_prop(ctx, -3, DUK_DEFPROP_HAVE_GETTER | DUK_DEFPROP_HAVE_ENUMERABLE | DUK_DEFPROP_ENUMERABLE);
+        };
+
+        duk_push_object(dukCtx.get());
+        duk_push_c_function(dukCtx.get(), DukRuntimeCurrentFrame, 0);
+        duk_put_prop_string(dukCtx.get(), -2, "currentFrame");
+        duk_push_c_function(dukCtx.get(), DukRuntimeObjectCount, 0);
+        duk_put_prop_string(dukCtx.get(), -2, "objectCount");
+        duk_push_c_function(dukCtx.get(), DukRuntimeTriggerEvent, 1);
+        duk_put_prop_string(dukCtx.get(), -2, "triggerEvent");
+        duk_put_prop_string(dukCtx.get(), -2, "runtime");
+
+        duk_push_object(dukCtx.get());
+        duk_push_boolean(dukCtx.get(), 1);
+        duk_put_prop_string(dukCtx.get(), -2, "available");
+        defineGetter(dukCtx.get(), "xLeft", DukFrameXLeft);
+        defineGetter(dukCtx.get(), "xRight", DukFrameXRight);
+        defineGetter(dukCtx.get(), "yTop", DukFrameYTop);
+        defineGetter(dukCtx.get(), "yBottom", DukFrameYBottom);
+        defineGetter(dukCtx.get(), "width", DukFrameWidth);
+        defineGetter(dukCtx.get(), "height", DukFrameHeight);
+        defineGetter(dukCtx.get(), "virtualWidth", DukFrameVirtualWidth);
+        defineGetter(dukCtx.get(), "virtualHeight", DukFrameVirtualHeight);
+        duk_push_c_function(dukCtx.get(), DukFrameTestPoint, DUK_VARARGS);
+        duk_put_prop_string(dukCtx.get(), -2, "testPoint");
+        duk_push_c_function(dukCtx.get(), DukFrameTestRect, DUK_VARARGS);
+        duk_put_prop_string(dukCtx.get(), -2, "testRect");
+        duk_put_prop_string(dukCtx.get(), -2, "frame");
+
+        duk_push_object(dukCtx.get());
+        duk_push_boolean(dukCtx.get(), 1);
+        duk_put_prop_string(dukCtx.get(), -2, "available");
+        duk_push_c_function(dukCtx.get(), DukKeyboardKeyDown, 1);
+        duk_put_prop_string(dukCtx.get(), -2, "keyDown");
+        duk_push_c_function(dukCtx.get(), DukKeyboardKeyUp, 1);
+        duk_put_prop_string(dukCtx.get(), -2, "keyUp");
+        duk_put_prop_string(dukCtx.get(), -2, "keyboard");
+
+        duk_push_object(dukCtx.get());
+        duk_push_boolean(dukCtx.get(), 1);
+        duk_put_prop_string(dukCtx.get(), -2, "available");
+        defineGetter(dukCtx.get(), "x", DukMouseX);
+        defineGetter(dukCtx.get(), "y", DukMouseY);
+        defineGetter(dukCtx.get(), "clientX", DukMouseClientX);
+        defineGetter(dukCtx.get(), "clientY", DukMouseClientY);
+        defineGetter(dukCtx.get(), "wheelDelta", DukMouseWheelDelta);
+        duk_push_c_function(dukCtx.get(), DukMouseButtonDown, 1);
+        duk_put_prop_string(dukCtx.get(), -2, "buttonDown");
+        duk_push_c_function(dukCtx.get(), DukMouseButtonUp, 1);
+        duk_put_prop_string(dukCtx.get(), -2, "buttonUp");
+        duk_put_prop_string(dukCtx.get(), -2, "mouse");
+
+        duk_push_object(dukCtx.get());
+        duk_push_boolean(dukCtx.get(), 1);
+        duk_put_prop_string(dukCtx.get(), -2, "available");
+        defineGetter(dukCtx.get(), "width", DukWindowWidth);
+        defineGetter(dukCtx.get(), "height", DukWindowHeight);
+        defineGetter(dukCtx.get(), "clientWidth", DukWindowClientWidth);
+        defineGetter(dukCtx.get(), "clientHeight", DukWindowClientHeight);
+        defineGetter(dukCtx.get(), "frameWidth", DukWindowFrameWidth);
+        defineGetter(dukCtx.get(), "frameHeight", DukWindowFrameHeight);
+        duk_put_prop_string(dukCtx.get(), -2, "window");
+
+        duk_push_c_function(dukCtx.get(), DukMMFIUnsupported, DUK_VARARGS);
+        duk_set_magic(dukCtx.get(), -1, 4);
+        duk_put_prop_string(dukCtx.get(), -2, "newObject");
+
+        duk_push_c_function(dukCtx.get(), DukMMFIUnsupported, DUK_VARARGS);
+        duk_set_magic(dukCtx.get(), -1, 5);
+        duk_put_prop_string(dukCtx.get(), -2, "newObjectClass");
+
+#ifdef _WIN32
+        duk_push_int(dukCtx.get(), VK_LEFT);
+        duk_put_prop_string(dukCtx.get(), -2, "VK_LEFT");
+        duk_push_int(dukCtx.get(), VK_RIGHT);
+        duk_put_prop_string(dukCtx.get(), -2, "VK_RIGHT");
+        duk_push_int(dukCtx.get(), VK_UP);
+        duk_put_prop_string(dukCtx.get(), -2, "VK_UP");
+        duk_push_int(dukCtx.get(), VK_DOWN);
+        duk_put_prop_string(dukCtx.get(), -2, "VK_DOWN");
+        duk_push_int(dukCtx.get(), VK_SPACE);
+        duk_put_prop_string(dukCtx.get(), -2, "VK_SPACE");
+        duk_push_int(dukCtx.get(), VK_RETURN);
+        duk_put_prop_string(dukCtx.get(), -2, "VK_RETURN");
+        duk_push_int(dukCtx.get(), VK_ESCAPE);
+        duk_put_prop_string(dukCtx.get(), -2, "VK_ESCAPE");
+        duk_push_int(dukCtx.get(), VK_SHIFT);
+        duk_put_prop_string(dukCtx.get(), -2, "VK_SHIFT");
+        duk_push_int(dukCtx.get(), VK_CONTROL);
+        duk_put_prop_string(dukCtx.get(), -2, "VK_CONTROL");
+        duk_push_int(dukCtx.get(), VK_MENU);
+        duk_put_prop_string(dukCtx.get(), -2, "VK_ALT");
+#endif
+
+        duk_push_string(dukCtx.get(), "Duktape 2.7.0");
+        duk_put_prop_string(dukCtx.get(), -2, "interpreter");
+
+        duk_push_string(dukCtx.get(), "MMFI runtime subset");
+        duk_put_prop_string(dukCtx.get(), -2, "api");
+
+        duk_put_prop_string(dukCtx.get(), -2, "mmf");
+        duk_pop(dukCtx.get());
+}
+
+bool Extension::EvalJavaScript(const std::tstring_view code, bool triggerEvents)
+{
+	if (!dukCtx)
+		InitialiseContext();
+	if (!dukCtx)
+		return false;
+
+        lastError.clear();
+        lastResultText.clear();
+        hasNumericResult = false;
+        lastResultBoolean = false;
+        lastResultKind = ResultKind::None;
+
+        const std::string utf8 = DarkEdif::TStringToUTF8(code);
+        duk_int_t evalResult = duk_peval_lstring(dukCtx.get(), utf8.c_str(), utf8.size());
+        if (evalResult != 0)
+        {
+                std::tstring err = DarkEdif::UTF8ToTString(duk_safe_to_string(dukCtx.get(), -1));
+
+                if (duk_is_object(dukCtx.get(), -1))
+                {
+                        if (duk_get_prop_string(dukCtx.get(), -1, "stack"))
+                        {
+                                std::tstring stack = DarkEdif::UTF8ToTString(duk_safe_to_string(dukCtx.get(), -1));
+                                if (!stack.empty())
+                                        err += _T("\n") + stack;
+                        }
+                        duk_pop(dukCtx.get());
+                }
+                duk_pop(dukCtx.get());
+                RecordError(err, triggerEvents);
+                return false;
+        }
+
+        if (duk_is_number(dukCtx.get(), -1))
+        {
+                lastResultNumber = duk_get_number(dukCtx.get(), -1);
+                hasNumericResult = true;
+                lastResultKind = ResultKind::Number;
+        }
+        else if (duk_is_boolean(dukCtx.get(), -1))
+        {
+                lastResultBoolean = duk_get_boolean(dukCtx.get(), -1) != 0;
+                lastResultKind = ResultKind::Boolean;
+        }
+        else if (duk_is_string(dukCtx.get(), -1))
+        {
+                lastResultKind = ResultKind::String;
+        }
+        else
+        {
+                lastResultKind = ResultKind::None;
+        }
+        lastResultText = DarkEdif::UTF8ToTString(duk_safe_to_string(dukCtx.get(), -1));
+        duk_pop(dukCtx.get());
+        return true;
+}
+
+void Extension::RecordError(const std::tstring& message, bool triggerEvents)
+{
+	lastError = message;
+	pendingErrorEvent = true;
+	if (triggerEvents)
+		Runtime.GenerateEvent(0);
+}
+
+void Extension::ProbeClassSupport()
+{
+        if (!dukCtx)
+                return;
+	const char* probeScript =
+		"class __DarkDuktapeProbe { constructor(v){this.v=v;} value(){return this.v;} }"
+		"; (new __DarkDuktapeProbe(1234)).value();";
+	if (duk_peval_string(dukCtx.get(), probeScript) == 0)
+	{
+		if (duk_is_number(dukCtx.get(), -1) && std::fabs(duk_get_number(dukCtx.get(), -1) - 1234.0) < 0.001)
+			classSyntaxSupported = true;
+	}
+        duk_pop(dukCtx.get());
+}
+
+void Extension::ProbeClasses()
+{
+        if (!dukCtx)
+                InitialiseContext();
+
+        if (!dukCtx)
+                return;
+
+        ProbeClassSupport();
+}
+
+Extension* Extension::FromCtx(duk_context* ctx)
+{
+	duk_push_heap_stash(ctx);
+	duk_get_prop_string(ctx, -1, "ext_ptr");
+	auto* ext = static_cast<Extension*>(duk_get_pointer(ctx, -1));
+	duk_pop_2(ctx);
+	return ext;
+}
+
+duk_ret_t Extension::DukRuntimeCurrentFrame(duk_context* ctx)
+{
+	auto* ext = FromCtx(ctx);
+	duk_push_int(ctx, ext ? ext->Runtime.GetCurrentFusionFrameNumber() : 0);
+	return 1;
+}
+
+duk_ret_t Extension::DukRuntimeObjectCount(duk_context* ctx)
+{
+	auto* ext = FromCtx(ctx);
+	duk_push_int(ctx, (ext && ext->rhPtr) ? static_cast<int>(ext->rhPtr->get_NObjects()) : 0);
+	return 1;
+}
+
+duk_ret_t Extension::DukRuntimeTriggerEvent(duk_context* ctx)
+{
+        auto* ext = FromCtx(ctx);
+        if (!ext)
+                return 0;
+        duk_int_t eventId = duk_is_number(ctx, 0) ? duk_get_int(ctx, 0) : 0;
+        ext->Runtime.GenerateEvent(static_cast<int>(eventId));
+        return 0;
+}
+
+duk_ret_t Extension::DukFrameXLeft(duk_context* ctx)
+{
+        auto* ext = FromCtx(ctx);
+        if (!ext || !ext->rhPtr)
+                return 0;
+        duk_push_int(ctx, ext->rhPtr->rh3.rh3DisplayX);
+        return 1;
+}
+
+duk_ret_t Extension::DukFrameXRight(duk_context* ctx)
+{
+        auto* ext = FromCtx(ctx);
+        if (!ext || !ext->rhPtr)
+                return 0;
+        duk_push_int(ctx, ext->rhPtr->rh3.rh3DisplayX + ext->rhPtr->rh3.rh3WindowSx);
+        return 1;
+}
+
+duk_ret_t Extension::DukFrameYTop(duk_context* ctx)
+{
+        auto* ext = FromCtx(ctx);
+        if (!ext || !ext->rhPtr)
+                return 0;
+        duk_push_int(ctx, ext->rhPtr->rh3.rh3DisplayY);
+        return 1;
+}
+
+duk_ret_t Extension::DukFrameYBottom(duk_context* ctx)
+{
+        auto* ext = FromCtx(ctx);
+        if (!ext || !ext->rhPtr)
+                return 0;
+        duk_push_int(ctx, ext->rhPtr->rh3.rh3DisplayY + ext->rhPtr->rh3.rh3WindowSy);
+        return 1;
+}
+
+duk_ret_t Extension::DukFrameWidth(duk_context* ctx)
+{
+        auto* ext = FromCtx(ctx);
+        if (!ext || !ext->rhPtr || !ext->rhPtr->rhFrame)
+                return 0;
+        duk_push_int(ctx, ext->rhPtr->rhFrame->m_hdr.leWidth);
+        return 1;
+}
+
+duk_ret_t Extension::DukFrameHeight(duk_context* ctx)
+{
+        auto* ext = FromCtx(ctx);
+        if (!ext || !ext->rhPtr || !ext->rhPtr->rhFrame)
+                return 0;
+        duk_push_int(ctx, ext->rhPtr->rhFrame->m_hdr.leHeight);
+        return 1;
+}
+
+duk_ret_t Extension::DukFrameVirtualWidth(duk_context* ctx)
+{
+        auto* ext = FromCtx(ctx);
+        if (!ext || !ext->rhPtr)
+                return 0;
+        duk_push_int(ctx, ext->rhPtr->rhLevelSx);
+        return 1;
+}
+
+duk_ret_t Extension::DukFrameVirtualHeight(duk_context* ctx)
+{
+        auto* ext = FromCtx(ctx);
+        if (!ext || !ext->rhPtr)
+                return 0;
+        duk_push_int(ctx, ext->rhPtr->rhLevelSy);
+        return 1;
+}
+
+duk_ret_t Extension::DukFrameTestPoint(duk_context* ctx)
+{
+        auto* ext = FromCtx(ctx);
+        if (!ext || !ext->rhPtr)
+                return 0;
+        const int nargs = duk_get_top(ctx);
+        if (nargs < 2 || !duk_is_number(ctx, 0) || !duk_is_number(ctx, 1))
+                return 0;
+        const int x = duk_get_int(ctx, 0);
+        const int y = duk_get_int(ctx, 1);
+        const bool insideX = x >= ext->rhPtr->rh3.rh3DisplayX && x <= (ext->rhPtr->rh3.rh3DisplayX + ext->rhPtr->rh3.rh3WindowSx);
+        const bool insideY = y >= ext->rhPtr->rh3.rh3DisplayY && y <= (ext->rhPtr->rh3.rh3DisplayY + ext->rhPtr->rh3.rh3WindowSy);
+        duk_push_boolean(ctx, insideX && insideY);
+        return 1;
+}
+
+duk_ret_t Extension::DukFrameTestRect(duk_context* ctx)
+{
+        auto* ext = FromCtx(ctx);
+        if (!ext || !ext->rhPtr)
+                return 0;
+        const int nargs = duk_get_top(ctx);
+        if (nargs < 4 || !duk_is_number(ctx, 0) || !duk_is_number(ctx, 1) || !duk_is_number(ctx, 2) || !duk_is_number(ctx, 3))
+                return 0;
+        const int x = duk_get_int(ctx, 0);
+        const int y = duk_get_int(ctx, 1);
+        const int w = duk_get_int(ctx, 2);
+        const int h = duk_get_int(ctx, 3);
+        const int left = ext->rhPtr->rh3.rh3DisplayX;
+        const int top = ext->rhPtr->rh3.rh3DisplayY;
+        const int right = left + ext->rhPtr->rh3.rh3WindowSx;
+        const int bottom = top + ext->rhPtr->rh3.rh3WindowSy;
+        const bool intersects = (x < right && (x + w) > left && y < bottom && (y + h) > top);
+        duk_push_boolean(ctx, intersects);
+        return 1;
+}
+
+duk_ret_t Extension::DukKeyboardKeyDown(duk_context* ctx)
+{
+        const duk_int_t key = duk_is_number(ctx, 0) ? duk_get_int(ctx, 0) : 0;
+#ifdef _WIN32
+        const short state = GetAsyncKeyState(static_cast<int>(key));
+        duk_push_boolean(ctx, (state & 0x8000) != 0);
+#else
+        (void)key;
+        duk_push_boolean(ctx, 0);
+#endif
+        return 1;
+}
+
+duk_ret_t Extension::DukKeyboardKeyUp(duk_context* ctx)
+{
+        const duk_int_t key = duk_is_number(ctx, 0) ? duk_get_int(ctx, 0) : 0;
+#ifdef _WIN32
+        const short state = GetAsyncKeyState(static_cast<int>(key));
+        duk_push_boolean(ctx, (state & 0x8000) == 0);
+#else
+        (void)key;
+        duk_push_boolean(ctx, 1);
+#endif
+        return 1;
+}
+
+duk_ret_t Extension::DukMouseX(duk_context* ctx)
+{
+        auto* ext = FromCtx(ctx);
+        if (!ext || !ext->rhPtr)
+                return 0;
+        duk_push_int(ctx, ext->rhPtr->rh2.rh2Mouse.x);
+        return 1;
+}
+
+duk_ret_t Extension::DukMouseY(duk_context* ctx)
+{
+        auto* ext = FromCtx(ctx);
+        if (!ext || !ext->rhPtr)
+                return 0;
+        duk_push_int(ctx, ext->rhPtr->rh2.rh2Mouse.y);
+        return 1;
+}
+
+duk_ret_t Extension::DukMouseClientX(duk_context* ctx)
+{
+        auto* ext = FromCtx(ctx);
+        if (!ext || !ext->rhPtr)
+                return 0;
+        duk_push_int(ctx, ext->rhPtr->rh2.rh2MouseClient.x);
+        return 1;
+}
+
+duk_ret_t Extension::DukMouseClientY(duk_context* ctx)
+{
+        auto* ext = FromCtx(ctx);
+        if (!ext || !ext->rhPtr)
+                return 0;
+        duk_push_int(ctx, ext->rhPtr->rh2.rh2MouseClient.y);
+        return 1;
+}
+
+duk_ret_t Extension::DukMouseWheelDelta(duk_context* ctx)
+{
+        auto* ext = FromCtx(ctx);
+        if (!ext || !ext->rhPtr)
+                return 0;
+        duk_push_int(ctx, ext->rhPtr->rh4.rh4MouseWheelDelta);
+        return 1;
+}
+
+duk_ret_t Extension::DukMouseButtonDown(duk_context* ctx)
+{
+        const duk_int_t button = duk_is_number(ctx, 0) ? duk_get_int(ctx, 0) : 0;
+#ifdef _WIN32
+        short state = 0;
+        switch (button)
+        {
+        case 1: state = GetAsyncKeyState(VK_LBUTTON); break;
+        case 2: state = GetAsyncKeyState(VK_MBUTTON); break;
+        case 3: state = GetAsyncKeyState(VK_RBUTTON); break;
+        case 4: state = GetAsyncKeyState(VK_XBUTTON1); break;
+        case 5: state = GetAsyncKeyState(VK_XBUTTON2); break;
+        default: state = 0; break;
+        }
+        duk_push_boolean(ctx, (state & 0x8000) != 0);
+#else
+        (void)button;
+        duk_push_boolean(ctx, 0);
+#endif
+        return 1;
+}
+
+duk_ret_t Extension::DukMouseButtonUp(duk_context* ctx)
+{
+        const duk_int_t button = duk_is_number(ctx, 0) ? duk_get_int(ctx, 0) : 0;
+#ifdef _WIN32
+        short state = 0;
+        switch (button)
+        {
+        case 1: state = GetAsyncKeyState(VK_LBUTTON); break;
+        case 2: state = GetAsyncKeyState(VK_MBUTTON); break;
+        case 3: state = GetAsyncKeyState(VK_RBUTTON); break;
+        case 4: state = GetAsyncKeyState(VK_XBUTTON1); break;
+        case 5: state = GetAsyncKeyState(VK_XBUTTON2); break;
+        default: state = 0; break;
+        }
+        duk_push_boolean(ctx, (state & 0x8000) == 0);
+#else
+        (void)button;
+        duk_push_boolean(ctx, 1);
+#endif
+        return 1;
+}
+
+duk_ret_t Extension::DukWindowWidth(duk_context* ctx)
+{
+        auto* ext = FromCtx(ctx);
+#ifdef _WIN32
+        if (!ext || !ext->rhPtr)
+                return 0;
+        RECT rc{};
+        GetWindowRect(ext->rhPtr->rhHMainWin, &rc);
+        duk_push_int(ctx, rc.right - rc.left);
+        return 1;
+#else
+        (void)ext;
+        return 0;
+#endif
+}
+
+duk_ret_t Extension::DukWindowHeight(duk_context* ctx)
+{
+        auto* ext = FromCtx(ctx);
+#ifdef _WIN32
+        if (!ext || !ext->rhPtr)
+                return 0;
+        RECT rc{};
+        GetWindowRect(ext->rhPtr->rhHMainWin, &rc);
+        duk_push_int(ctx, rc.bottom - rc.top);
+        return 1;
+#else
+        (void)ext;
+        return 0;
+#endif
+}
+
+duk_ret_t Extension::DukWindowClientWidth(duk_context* ctx)
+{
+        auto* ext = FromCtx(ctx);
+#ifdef _WIN32
+        if (!ext || !ext->rhPtr)
+                return 0;
+        RECT rc{};
+        GetClientRect(ext->rhPtr->rhHMainWin, &rc);
+        duk_push_int(ctx, rc.right - rc.left);
+        return 1;
+#else
+        (void)ext;
+        return 0;
+#endif
+}
+
+duk_ret_t Extension::DukWindowClientHeight(duk_context* ctx)
+{
+        auto* ext = FromCtx(ctx);
+#ifdef _WIN32
+        if (!ext || !ext->rhPtr)
+                return 0;
+        RECT rc{};
+        GetClientRect(ext->rhPtr->rhHMainWin, &rc);
+        duk_push_int(ctx, rc.bottom - rc.top);
+        return 1;
+#else
+        (void)ext;
+        return 0;
+#endif
+}
+
+duk_ret_t Extension::DukWindowFrameWidth(duk_context* ctx)
+{
+        auto* ext = FromCtx(ctx);
+#ifdef _WIN32
+        if (!ext || !ext->rhPtr)
+                return 0;
+        RECT rc{};
+        GetWindowRect(ext->rhPtr->rhHEditWin, &rc);
+        duk_push_int(ctx, rc.right - rc.left);
+        return 1;
+#else
+        (void)ext;
+        return 0;
+#endif
+}
+
+duk_ret_t Extension::DukWindowFrameHeight(duk_context* ctx)
+{
+        auto* ext = FromCtx(ctx);
+#ifdef _WIN32
+        if (!ext || !ext->rhPtr)
+                return 0;
+        RECT rc{};
+        GetWindowRect(ext->rhPtr->rhHEditWin, &rc);
+        duk_push_int(ctx, rc.bottom - rc.top);
+        return 1;
+#else
+        (void)ext;
+        return 0;
+#endif
+}
+
+duk_ret_t Extension::DukMMFIUnsupported(duk_context* ctx)
+{
+        const duk_int_t magic = duk_get_current_magic(ctx);
+        const char* feature = "mmf feature";
+
+        switch (magic)
+        {
+        case 0: feature = "mmf.frame"; break;
+        case 1: feature = "mmf.keyboard"; break;
+        case 2: feature = "mmf.mouse"; break;
+        case 3: feature = "mmf.window"; break;
+        case 4: feature = "mmf.newObject"; break;
+        case 5: feature = "mmf.newObjectClass"; break;
+        default: break;
+        }
+
+        duk_error(ctx, DUK_ERR_ERROR, "%s is not implemented in the Duktape port of MMFI yet.", feature);
+        return DUK_RET_ERROR;
 }

--- a/DarkEdif/DarkEdif Template/Extension.hpp
+++ b/DarkEdif/DarkEdif Template/Extension.hpp
@@ -1,5 +1,7 @@
 #pragma once
 #include "DarkEdif.hpp"
+#include "duktape.h"
+#include <memory>
 
 class Extension final
 {
@@ -42,73 +44,89 @@ public:
 	// Extension data
 	// ======================================
 
-	// To add items to the Fusion Debugger, just uncomment this line.
 	DarkEdif::FusionDebugger FusionDebugger;
-	// After enabling it, you run FusionDebugger.AddItemToDebugger() inside Extension's constructor
-	// As an example:
-	std::tstring exampleDebuggerTextItem;
 
-
-	/*  Add any data you want to store in your extension to this class
-		(eg. what you'd normally store in rdPtr in old SDKs).
-
-		Unlike rdPtr, you can store real C++ objects with constructors
-		and destructors, without having to call them manually or store
-		a pointer.
-	*/
-
-	// int MyVariable;
-
-
-	/*  Add your actions, conditions and expressions as real class member
-		functions here. The arguments (and return type for expressions) must
-		match EXACTLY what you defined in the JSON.
-
-		Remember to link the actions, conditions and expressions to their
-		numeric IDs in the class constructor (Extension.cpp)
-	*/
+	// Persistent scripting state
+	using DukContextPtr = std::unique_ptr<duk_context, decltype(&duk_destroy_heap)>;
+	DukContextPtr dukCtx { nullptr, &duk_destroy_heap };
+	bool pendingErrorEvent = false;
+	bool classSyntaxSupported = false;
+	bool exposeMMFIOnStart = true;
+	bool probeClassesOnStart = true;
+	std::tstring bootstrapCode;
+        std::tstring lastError;
+        std::tstring lastResultText;
+        double lastResultNumber = 0.0;
+        bool hasNumericResult = false;
+        bool lastResultBoolean = false;
+        enum class ResultKind
+        {
+                None = 0,
+                Number,
+                Boolean,
+                String
+        };
+        ResultKind lastResultKind = ResultKind::None;
 
 	// Actions
-
-	void ActionExample(int ExampleParameter);
-	void SecondActionExample();
+	void ResetContext();
+	void RunJavaScript(const TCHAR * code);
+	void CallFunctionExpression(const TCHAR * callText);
+        void RebuildMMFI();
+        void ProbeClasses();
 
 	// Conditions
-
-	bool AreTwoNumbersEqual(int FirstNumber, int SecondNumber);
+	bool OnJavaScriptError();
 
 	// Expressions
+	const TCHAR * LastResult();
+	double LastNumber();
+        const TCHAR * LastError();
+        int ClassSupport();
+        int CurrentFrameIndex();
+        int ObjectCount();
+        int LastResultType();
+        int LastBoolean();
 
-	int Add(int FirstNumber, int SecondNumber);
-	const TCHAR * HelloWorld();
-
-	// Runs every tick of Fusion's runtime, can be toggled off and back on
 	REFLAG Handle();
 
-#if TEXT_OEFLAG_EXTENSION
-	// Extension text struct. Required for text exts.
-	DarkEdif::FontInfoMultiPlat font;
-	void OnFontChanged(bool colorEdit, DarkEdif::Rect* rc);
-#endif
-#if DARKEDIF_DISPLAY_TYPE == DARKEDIF_DISPLAY_SIMPLE
-	// Extension display surface ptr. Required for simple display exts.
-	DarkEdif::Surface * surf = nullptr;
-#elif DARKEDIF_DISPLAY_TYPE == DARKEDIF_DISPLAY_MANUAL
-	void Display();
-	void GetZoneInfos();
-	DarkEdif::Surface * GetDisplaySurface();
-	DarkEdif::CollisionMask * GetCollisionMask(std::uint32_t flags);
-#endif
-
-	// These are called if there's no function linked to an ID
 	void UnlinkedAction(int ID);
 	long UnlinkedCondition(int ID);
 	long UnlinkedExpression(int ID);
 
-#if PAUSABLE_EXTENSION
-	// Called when Fusion runtime is pausing - not just the F3 pause dialog
-	void FusionRuntimePaused();
-	// Called when Fusion runtime is resuming after a pause
-	void FusionRuntimeContinued();
-#endif // PAUSABLE_EXTENSION
+	void InitialiseContext();
+        void RegisterMMFIHelpers();
+        bool EvalJavaScript(const std::tstring_view code, bool triggerEvents = true);
+        void RecordError(const std::tstring & message, bool triggerEvents);
+        void ProbeClassSupport();
+        static Extension * FromCtx(duk_context * ctx);
+        static duk_ret_t DukRuntimeCurrentFrame(duk_context * ctx);
+        static duk_ret_t DukRuntimeObjectCount(duk_context * ctx);
+        static duk_ret_t DukRuntimeTriggerEvent(duk_context * ctx);
+        static duk_ret_t DukFrameXLeft(duk_context * ctx);
+        static duk_ret_t DukFrameXRight(duk_context * ctx);
+        static duk_ret_t DukFrameYTop(duk_context * ctx);
+        static duk_ret_t DukFrameYBottom(duk_context * ctx);
+        static duk_ret_t DukFrameWidth(duk_context * ctx);
+        static duk_ret_t DukFrameHeight(duk_context * ctx);
+        static duk_ret_t DukFrameVirtualWidth(duk_context * ctx);
+        static duk_ret_t DukFrameVirtualHeight(duk_context * ctx);
+        static duk_ret_t DukFrameTestPoint(duk_context * ctx);
+        static duk_ret_t DukFrameTestRect(duk_context * ctx);
+        static duk_ret_t DukKeyboardKeyDown(duk_context * ctx);
+        static duk_ret_t DukKeyboardKeyUp(duk_context * ctx);
+        static duk_ret_t DukMouseX(duk_context * ctx);
+        static duk_ret_t DukMouseY(duk_context * ctx);
+        static duk_ret_t DukMouseClientX(duk_context * ctx);
+        static duk_ret_t DukMouseClientY(duk_context * ctx);
+        static duk_ret_t DukMouseWheelDelta(duk_context * ctx);
+        static duk_ret_t DukMouseButtonDown(duk_context * ctx);
+        static duk_ret_t DukMouseButtonUp(duk_context * ctx);
+        static duk_ret_t DukWindowWidth(duk_context * ctx);
+        static duk_ret_t DukWindowHeight(duk_context * ctx);
+        static duk_ret_t DukWindowClientWidth(duk_context * ctx);
+        static duk_ret_t DukWindowClientHeight(duk_context * ctx);
+        static duk_ret_t DukWindowFrameWidth(duk_context * ctx);
+        static duk_ret_t DukWindowFrameHeight(duk_context * ctx);
+        static duk_ret_t DukMMFIUnsupported(duk_context * ctx);
 };

--- a/DarkEdif/DarkEdif Template/MMFI_COMPARISON.md
+++ b/DarkEdif/DarkEdif Template/MMFI_COMPARISON.md
@@ -1,0 +1,20 @@
+# MMFI surface comparison: XLua vs. Duktape port
+
+This document highlights the exposed pieces of the `mmf` table in the Duktape-backed extension and how they map to XLua's MMFI API. XLua's shipping MMFI exposes five default objects (`frame`, `keyboard`, `mouse`, `runtime`, `window`) and constructors (`newObject`, `newObjectClass`) alongside a rich set of object/class helpers. The current port keeps the namespace compatible while only implementing a subset of the runtime helpers.
+
+## Implemented compatibility points
+- `mmf.interpreter` and `mmf.api` strings are present so scripts can detect the port and version.
+- `mmf.runtime.currentFrame()` mirrors XLua's ability to read the current frame index.
+- `mmf.runtime.objectCount()` exposes the active object count just like XLua's runtime helper.
+- `mmf.runtime.triggerEvent(id)` lets scripts raise Fusion events from JavaScript.
+- `mmf.frame` now exposes live properties for `xLeft`, `xRight`, `yTop`, `yBottom`, `width`, `height`, `virtualWidth`, and `virtualHeight` plus `testPoint`/`testRect` helpers that validate coordinates against the current viewport.
+- `mmf.keyboard.keyDown(key)` / `keyUp(key)` poll the state of a virtual key, and `VK_*` constants (arrows, space, return, escape, shift, control, alt) are populated on Windows builds for convenience.
+- `mmf.mouse` surfaces `x`, `y`, `clientX`, `clientY`, `wheelDelta`, `buttonDown(button)`, and `buttonUp(button)` (1=left, 2=middle, 3=right, 4/5=XButtons) using Fusion's runtime state.
+- `mmf.window` provides `width`, `height`, `clientWidth`, `clientHeight`, `frameWidth`, and `frameHeight` derived from the main and edit window handles on Windows.
+
+## Stubbed, not yet implemented
+- `mmf.newObject(...)` and `mmf.newObjectClass(...)` exist but immediately raise an error to highlight that object/class construction is not yet supported.
+- Frame collision helpers still perform viewport-bound checks only; backdrop/object collision parity with XLua is not yet available.
+
+## Behavior when missing features are used
+Calling any of the stubbed members will raise a Duktape error identifying the missing feature so scripts can fall back or guard against unavailable APIs at runtime.


### PR DESCRIPTION
## Summary
- expose frame, keyboard, mouse, and window helpers in the Duktape mmf namespace with live getters and event-safe runtime calls
- add viewport-based test helpers along with Windows VK constants to mirror core XLua MMFI ergonomics
- document the newly implemented MMFI surface and remaining gaps compared to XLua

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943aa132094832c8bffe5afc5753a58)